### PR TITLE
feat: add info command for detailed model view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Filter by domain, framework, GPU requirement
   - Pagination and result limiting
   - User-friendly result display
-- Comprehensive test suite for catalog operations (9 tests)
+- CLI `info` command to view detailed model information
+  - Display model metadata, version details, and hardware requirements
+  - Show benchmark results and performance metrics
+  - Display citation information with formatted author list
+  - Comprehensive view of all model attributes
+- Comprehensive test suite for catalog operations (10 tests)
 
 ### Changed
 - CI pipeline now tests only Go 1.23 (previously tested 1.22 and 1.23)

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -423,6 +423,68 @@ func createTestModelWithDetails(name, domain, framework string, gpuRequired bool
 	return m
 }
 
+func TestGetModel_WithCitation(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	model := &types.Model{
+		Name:        "cited-model",
+		Version:     "1.0.0",
+		Domain:      "protein-science",
+		Description: "Model with citation",
+		Runtime: types.Runtime{
+			Framework:     "pytorch",
+			PythonVersion: "3.11",
+		},
+		Inference: types.Inference{
+			Entrypoint: "inference.py",
+			Handler:    "predict",
+		},
+		WeightsURI: "s3://test/weights",
+		Citation: types.Citation{
+			PaperTitle: "Test Paper",
+			Authors:    []string{"Author A", "Author B"},
+			Year:       2024,
+			DOI:        "10.1234/test",
+			PaperURL:   "https://example.com/paper",
+			BibTeX:     "@article{test2024, title={Test Paper}}",
+		},
+	}
+
+	_, err := db.CreateModel(model)
+	if err != nil {
+		t.Fatalf("CreateModel() error = %v", err)
+	}
+
+	// Retrieve and check citation
+	retrieved, err := db.GetModel("cited-model")
+	if err != nil {
+		t.Fatalf("GetModel() error = %v", err)
+	}
+
+	if retrieved.Citation == nil {
+		t.Fatal("Citation is nil")
+	}
+
+	c := retrieved.Citation
+	if c.PaperTitle != "Test Paper" {
+		t.Errorf("PaperTitle = %v, want Test Paper", c.PaperTitle)
+	}
+
+	if c.Year != 2024 {
+		t.Errorf("Year = %v, want 2024", c.Year)
+	}
+
+	if c.DOI != "10.1234/test" {
+		t.Errorf("DOI = %v, want 10.1234/test", c.DOI)
+	}
+
+	// Authors should be joined by comma in database
+	if c.Authors != "Author A, Author B" {
+		t.Errorf("Authors = %v, want 'Author A, Author B'", c.Authors)
+	}
+}
+
 func boolPtr(b bool) *bool {
 	return &b
 }

--- a/internal/catalog/repository.go
+++ b/internal/catalog/repository.go
@@ -134,6 +134,13 @@ func (db *DB) GetModel(name string) (*Model, error) {
 	}
 	m.LatestVersion = version
 
+	// Load citation
+	citation, err := db.getCitation(m.ID)
+	if err != nil && err != sql.ErrNoRows {
+		return nil, fmt.Errorf("failed to load citation: %w", err)
+	}
+	m.Citation = citation
+
 	return &m, nil
 }
 
@@ -202,6 +209,24 @@ func (db *DB) getBenchmarks(versionID int64) ([]Benchmark, error) {
 	}
 
 	return benchmarks, rows.Err()
+}
+
+// getCitation retrieves citation information for a model
+func (db *DB) getCitation(modelID int64) (*Citation, error) {
+	var c Citation
+	err := db.conn.QueryRow(`
+		SELECT id, model_id, paper_title, paper_url, doi, authors, year, bibtex
+		FROM citations
+		WHERE model_id = ?
+	`, modelID).Scan(
+		&c.ID, &c.ModelID, &c.PaperTitle, &c.PaperURL,
+		&c.DOI, &c.Authors, &c.Year, &c.BibTeX,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &c, nil
 }
 
 // ListModels retrieves all models with pagination

--- a/internal/catalog/types.go
+++ b/internal/catalog/types.go
@@ -15,6 +15,7 @@ type Model struct {
 
 	// Related data (not from DB directly)
 	LatestVersion *ModelVersion `db:"-"`
+	Citation      *Citation     `db:"-"`
 	Tags          []string      `db:"-"`
 }
 

--- a/internal/cli/info.go
+++ b/internal/cli/info.go
@@ -1,0 +1,167 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/scttfrdmn/conduit/internal/catalog"
+)
+
+var infoDbPath string
+
+var infoCmd = &cobra.Command{
+	Use:   "info <model-name>",
+	Short: "Show detailed information about a model",
+	Long: `Display comprehensive information about a model from the catalog.
+
+Shows model metadata, version details, hardware requirements,
+benchmarks, and citation information if available.
+
+Examples:
+  conduit info alphafold2
+  conduit info esm2-650m --db /custom/path/catalog.db`,
+	Args: cobra.ExactArgs(1),
+	RunE: runInfo,
+}
+
+func init() {
+	rootCmd.AddCommand(infoCmd)
+	infoCmd.Flags().StringVar(&infoDbPath, "db", "", "Path to catalog database (default: ~/.conduit/catalog.db)")
+}
+
+func runInfo(cmd *cobra.Command, args []string) (err error) {
+	modelName := args[0]
+
+	// Open catalog database
+	db, err := catalog.NewDB(infoDbPath)
+	if err != nil {
+		return fmt.Errorf("failed to open catalog: %w", err)
+	}
+	defer func() {
+		if closeErr := db.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("failed to close database: %w", closeErr)
+		}
+	}()
+
+	// Get model
+	model, err := db.GetModel(modelName)
+	if err != nil {
+		return fmt.Errorf("failed to get model: %w", err)
+	}
+
+	// Display model information
+	fmt.Printf("\n=== %s ===\n\n", model.Name)
+
+	// Basic info
+	fmt.Printf("Domain:      %s\n", model.Domain)
+	if model.Description != "" {
+		fmt.Printf("Description: %s\n", model.Description)
+	}
+	if model.GitHubRepo != "" {
+		fmt.Printf("GitHub:      %s\n", model.GitHubRepo)
+	}
+	if model.License != "" {
+		fmt.Printf("License:     %s\n", model.License)
+	}
+	fmt.Printf("Created:     %s\n", model.CreatedAt.Format("2006-01-02 15:04:05"))
+	fmt.Printf("Updated:     %s\n", model.UpdatedAt.Format("2006-01-02 15:04:05"))
+
+	// Version info
+	if model.LatestVersion != nil {
+		v := model.LatestVersion
+		fmt.Printf("\n--- Latest Version: %s ---\n\n", v.Version)
+
+		fmt.Printf("Weights URI:  %s\n", v.WeightsURI)
+		if v.WeightsSizeGB > 0 {
+			fmt.Printf("Weights Size: %.2f GB\n", v.WeightsSizeGB)
+		}
+		if v.ChecksumSHA256 != "" {
+			fmt.Printf("Checksum:     %s\n", v.ChecksumSHA256)
+		}
+
+		// Runtime
+		fmt.Printf("\n--- Runtime ---\n\n")
+		fmt.Printf("Framework:      %s\n", v.Framework)
+		fmt.Printf("Python Version: %s\n", v.PythonVersion)
+		if v.Dependencies != "" {
+			fmt.Printf("Dependencies:   %s\n", v.Dependencies)
+		}
+		if v.CustomImage != "" {
+			fmt.Printf("Custom Image:   %s\n", v.CustomImage)
+		}
+
+		// Inference
+		fmt.Printf("\n--- Inference ---\n\n")
+		fmt.Printf("Entrypoint: %s\n", v.Entrypoint)
+		fmt.Printf("Handler:    %s\n", v.Handler)
+
+		// Hardware
+		fmt.Printf("\n--- Hardware Requirements ---\n\n")
+		fmt.Printf("GPU Required: %v\n", v.GPURequired)
+		if v.RecommendedInstance != "" {
+			fmt.Printf("Recommended:  %s\n", v.RecommendedInstance)
+		}
+		if v.MinCPU > 0 {
+			fmt.Printf("Min CPU:      %d cores\n", v.MinCPU)
+		}
+		if v.MinMemoryGB > 0 {
+			fmt.Printf("Min Memory:   %d GB\n", v.MinMemoryGB)
+		}
+		if v.MinGPUMemoryGB > 0 {
+			fmt.Printf("Min GPU VRAM: %d GB\n", v.MinGPUMemoryGB)
+		}
+
+		// Benchmarks
+		if len(v.Benchmarks) > 0 {
+			fmt.Printf("\n--- Benchmarks ---\n\n")
+			for _, b := range v.Benchmarks {
+				fmt.Printf("Dataset: %s\n", b.Dataset)
+				fmt.Printf("  Metric:  %s = %.4f\n", b.Metric, b.Result)
+				if b.Instance != "" {
+					fmt.Printf("  Instance: %s\n", b.Instance)
+				}
+				if b.CostPerPrediction != "" {
+					fmt.Printf("  Cost/Prediction: %s\n", b.CostPerPrediction)
+				}
+				if b.WalltimeSeconds > 0 {
+					fmt.Printf("  Walltime: %.2fs\n", b.WalltimeSeconds)
+				}
+				fmt.Println()
+			}
+		}
+	}
+
+	// Citation
+	if model.Citation != nil {
+		c := model.Citation
+		fmt.Printf("\n--- Citation ---\n\n")
+		if c.PaperTitle != "" {
+			fmt.Printf("Title:   %s\n", c.PaperTitle)
+		}
+		if c.Authors != "" {
+			// Split authors by comma and format nicely
+			authors := strings.Split(c.Authors, ",")
+			fmt.Printf("Authors: %s\n", strings.TrimSpace(authors[0]))
+			for i := 1; i < len(authors); i++ {
+				fmt.Printf("         %s\n", strings.TrimSpace(authors[i]))
+			}
+		}
+		if c.Year > 0 {
+			fmt.Printf("Year:    %d\n", c.Year)
+		}
+		if c.DOI != "" {
+			fmt.Printf("DOI:     %s\n", c.DOI)
+		}
+		if c.PaperURL != "" {
+			fmt.Printf("URL:     %s\n", c.PaperURL)
+		}
+		if c.BibTeX != "" {
+			fmt.Printf("\nBibTeX:\n%s\n", c.BibTeX)
+		}
+	}
+
+	fmt.Println()
+	return nil
+}


### PR DESCRIPTION
## Summary

Implements the `conduit info <model-name>` command to display comprehensive information about models in the catalog.

- View model metadata (name, domain, description, license, timestamps)
- Display latest version details (weights URI, size, checksum, runtime)
- Show hardware requirements and recommendations
- List benchmark results with performance metrics
- Display citation information with formatted author list

## Changes

- Added `internal/cli/info.go` with runInfo command implementation
- Added `getCitation()` method to load citation data from database
- Added `Citation` field to `catalog.Model` struct
- Updated `GetModel()` to automatically load citation information
- Added test case for GetModel with citation
- Updated CHANGELOG with info command documentation

## Testing

- All catalog tests pass (10/10)
- Linting passes with 0 issues
- Command help and usage verified
- Build successful

## Example Usage

```bash
# View detailed information about a model
conduit info alphafold2

# Use custom database location
conduit info esm2-650m --db /custom/catalog.db
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)