### PR TITLE
feat: add list command to display all catalog models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Show benchmark results and performance metrics
   - Display citation information with formatted author list
   - Comprehensive view of all model attributes
+- CLI `list` command to display all models in catalog
+  - Paginated display with limit and offset support
+  - Shows model name, domain, description, and update date
+  - Total count and navigation hints
+  - Clean, user-friendly format
 - CLI `versions` command to list model version history
   - Shows all versions in reverse chronological order
   - Indicates which version is marked as latest

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/scttfrdmn/conduit/internal/catalog"
+)
+
+var (
+	listDbPath string
+	listLimit  int
+	listOffset int
+)
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all models in the catalog",
+	Long: `Display all models in the catalog with pagination.
+
+Shows model names, domains, and latest versions.
+
+Examples:
+  conduit list
+  conduit list --limit 50
+  conduit list --limit 10 --offset 20`,
+	Args: cobra.NoArgs,
+	RunE: runList,
+}
+
+func init() {
+	rootCmd.AddCommand(listCmd)
+	listCmd.Flags().StringVar(&listDbPath, "db", "", "Path to catalog database (default: ~/.conduit/catalog.db)")
+	listCmd.Flags().IntVar(&listLimit, "limit", 20, "Maximum number of models to display")
+	listCmd.Flags().IntVar(&listOffset, "offset", 0, "Number of models to skip")
+}
+
+func runList(cmd *cobra.Command, args []string) (err error) {
+	// Open catalog database
+	db, err := catalog.NewDB(listDbPath)
+	if err != nil {
+		return fmt.Errorf("failed to open catalog: %w", err)
+	}
+	defer func() {
+		if closeErr := db.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("failed to close database: %w", closeErr)
+		}
+	}()
+
+	// Get total count
+	total, err := db.CountModels()
+	if err != nil {
+		return fmt.Errorf("failed to count models: %w", err)
+	}
+
+	if total == 0 {
+		fmt.Println("No models in catalog.")
+		fmt.Println("\nPublish a model with: conduit publish model.yaml")
+		return nil
+	}
+
+	// List models
+	models, err := db.ListModels(listLimit, listOffset)
+	if err != nil {
+		return fmt.Errorf("failed to list models: %w", err)
+	}
+
+	if len(models) == 0 {
+		fmt.Printf("No models found at offset %d.\n", listOffset)
+		return nil
+	}
+
+	// Display header
+	fmt.Printf("\nModels in catalog (%d total):\n\n", total)
+
+	// Display models
+	for i, model := range models {
+		displayNum := listOffset + i + 1
+		fmt.Printf("%d. %s\n", displayNum, model.Name)
+		fmt.Printf("   Domain:  %s\n", model.Domain)
+
+		if model.Description != "" {
+			desc := model.Description
+			if len(desc) > 80 {
+				desc = desc[:77] + "..."
+			}
+			fmt.Printf("   Desc:    %s\n", desc)
+		}
+
+		fmt.Printf("   Updated: %s\n", model.UpdatedAt.Format("2006-01-02"))
+		fmt.Println()
+	}
+
+	// Show pagination info
+	showing := len(models)
+	rangeStart := listOffset + 1
+	rangeEnd := listOffset + showing
+
+	fmt.Printf("Showing %d-%d of %d models\n\n", rangeStart, rangeEnd, total)
+
+	// Show navigation hints
+	if rangeEnd < int(total) {
+		nextOffset := listOffset + listLimit
+		fmt.Printf("View more: conduit list --offset %d\n", nextOffset)
+	}
+
+	fmt.Printf("View details: conduit info <model-name>\n")
+	fmt.Printf("Search: conduit search <query>\n")
+
+	return nil
+}


### PR DESCRIPTION
## Summary

Implements a clean `conduit list` command for browsing all models in the catalog with pagination support.

## Features

**Display:**
- Model name, domain, description (truncated if > 80 chars), and update date
- Clean numbered format
- Total count indicator

**Pagination:**
- `--limit` flag (default: 20)
- `--offset` flag (default: 0)
- Shows current range (e.g., "Showing 1-20 of 45 models")
- Navigation hint when more results available

**User Experience:**
- Helpful empty state message when no models exist
- Next steps guidance (info, search commands)
- Consistent formatting with other CLI commands

## Usage Examples

```bash
# List first 20 models (default)
conduit list

# List first 50 models
conduit list --limit 50

# Skip first 20, show next batch
conduit list --offset 20

# Custom pagination
conduit list --limit 10 --offset 30
```

## Output Example

```
Models in catalog (45 total):

1. alphafold2-multimer
   Domain:  protein-science
   Desc:    AlphaFold 2 Multimer for protein complex structure prediction
   Updated: 2025-11-10

2. esm2-650m
   Domain:  protein-science
   Desc:    ESM-2 650M parameter protein language model
   Updated: 2025-11-09

...

Showing 1-20 of 45 models

View more: conduit list --offset 20
View details: conduit info <model-name>
Search: conduit search <query>
```

## Why This Command?

The `list` command complements `search` by providing a simple way to browse all models without filtering. Use cases:
- Discover what models are available
- Quick overview of catalog contents
- Browse models by update date
- Verify published models

## Testing

- Manual testing with empty catalog
- Testing with multiple models
- Pagination testing with various limits/offsets
- Clean output formatting verified
- 0 linting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)